### PR TITLE
Reverse monthly archives e.g. show 1-30 instead of 30-1

### DIFF
--- a/pepysdiary/templates/diary/entry_archive_month.html
+++ b/pepysdiary/templates/diary/entry_archive_month.html
@@ -7,7 +7,7 @@
 {% block header_title %}Diary entries from {{ month|date:"F" }}&nbsp;{{ month|date:"Y" }}{% endblock %}
 
 {% block main_content %}
-	{% include 'inc/entry_list.html' %}
+	{% include 'inc/entry_list.html' with reversed=True %}
 {% endblock main_content %}
 
 

--- a/pepysdiary/templates/diary/inc/entry_list.html
+++ b/pepysdiary/templates/diary/inc/entry_list.html
@@ -1,5 +1,11 @@
 <section class="entries">
-	{% for entry in entry_list %}
-		{% include 'inc/entry.html' with entry=entry in_list=True %}
-	{% endfor %}
+	{% if reversed %}
+		{% for entry in entry_list reversed %}
+			{% include 'inc/entry.html' with entry=entry in_list=True %}
+		{% endfor %}
+	{% else %}
+		{% for entry in entry_list %}
+			{% include 'inc/entry.html' with entry=entry in_list=True %}
+		{% endfor %}
+	{% endif %}
 </section>


### PR DESCRIPTION
Fix for https://github.com/philgyford/pepysdiary/issues/136

Untested as I don't have a full set-up.

I wonder if pepysdiary/templates/common/home.html needs `{% include 'inc/entry_list.html' with entry_list=entry_list|slice:"7" %}` to set `reversed=False`. A quick test will tell us.