### PR TITLE
Remove annotation links to deactivated accounts

### DIFF
--- a/pepysdiary/templates/comments/list.html
+++ b/pepysdiary/templates/comments/list.html
@@ -46,7 +46,11 @@ NOTE: The listings in templatetags/list_tags.py for the Recent Activity page
 				<h3 class="media-heading">
 					<span class="comment-name">
 						{% if comment.user %}
-							<a href="{{ comment.user.get_absolute_url }}" title="See more about this person">{{ comment.get_user_name }}</a>
+							{% if comment.user.is_active %}
+							   <a href="{{ comment.user.get_absolute_url }}" title="See more about this person">{{ comment.get_user_name }}</a>
+							{% else %}
+							  {{ comment.get_user_name }}
+							{% endif %}
 						{% elif comment.get_user_url %}
 							<a href="{{ comment.get_user_url }}" title="Visit this person’s website" rel="nofollow">{{ comment.get_user_name }}</a>
 						{% else %}

--- a/tests/annotations/test_templates.py
+++ b/tests/annotations/test_templates.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+from pepysdiary.annotations.factories import EntryAnnotationFactory
+from pepysdiary.diary.factories import EntryFactory
+from pepysdiary.membership.factories import PersonFactory
+
+class CommentTemplateTest(TestCase):
+    def setUp(self):
+        self.user = PersonFactory()
+        self.entry = EntryFactory()
+        self.annotation = EntryAnnotationFactory(content_object=self.entry, user=self.user)
+
+    def test_profile_link_enabled_when_user_active(self):
+        formatted_date = self.entry.diary_date.strftime("%Y/%m/%d")
+        expected_link = f'<a href="/account/profile/{self.user.id}/" title="See more about this person">{self.user.name}</a>'
+        response = self.client.get(f'/diary/{formatted_date}/')
+
+        self.assertContains(response, "1 Annotation", html=True)
+        self.assertContains(response, expected_link, html=True)
+
+    def test_profile_link_disabled_when_user_inactive(self):
+        self.user.is_active = False
+        self.user.save()
+
+        formatted_date = self.entry.diary_date.strftime("%Y/%m/%d")
+        expected_link = f'<a href="/account/profile/{self.user.id}/" title="See more about this person">{self.user.name}</a>'
+        response = self.client.get(f'/diary/{formatted_date}/')
+
+        self.assertContains(response, "1 Annotation", html=True)
+        self.assertNotContains(response, expected_link, html=True)


### PR DESCRIPTION
Fixes https://github.com/philgyford/pepysdiary/issues/486

<details>
  <summary>I had to make some minor changes to make the tests run locally (click for details)</summary>

When first running the tests locally I got the following error.

```
?: (debug_toolbar.E001) The Django Debug Toolbar can't be used with tests
HINT: Django changes the DEBUG setting to False when running tests. 
By default the Django Debug Toolbar is installed because DEBUG is set to True. 
For most cases, you need to avoid installing the toolbar when running tests. 
If you feel this check is in error, you can set `DEBUG_TOOLBAR_CONFIG['IS_RUNNING_TESTS'] = False` to bypass this check.
```

I fixed this by altering `settings.py` (as of L313) to not load the debug bar during tests.

I also got lots of errors like:

```
ERROR 2021-06-01 12:00:00,000 exception:124 Invalid HTTP_HOST header: 'example.com'. You may need to add 'example.com' to ALLOWED_HOSTS.
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.10/site-packages/django/utils/deprecation.py", line 133, in __call__
    response = self.process_request(request)
  File "/usr/local/lib/python3.10/site-packages/django/middleware/common.py", line 48, in process_request
    host = request.get_host()
  File "/usr/local/lib/python3.10/site-packages/django/http/request.py", line 151, in get_host
    raise DisallowedHost(msg)
django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: 'example.com'. You may need to add 'example.com' to ALLOWED_HOSTS.
```

To fix, I altered `settings.py` (as of L23) to specify the `ALLOWED_HOSTS` that Django was expecting.
</details>

<details>
  <summary>And encountered a small bug when creating annotations as a regular user on the dev site  (click for details)</summary>
  Going to any diary entry and posting an annotation takes you to to the preview screen (http://www.pepysdiary.test:8000/annotations/post/). As a regular user (i.e. not staff or admin), clicking <em>Post it</em> created the annotation in the database, but then raised an "Invalid URL error".

```
InvalidURL at /annotations/post/
URL has an invalid label.

Request Method: POST
Request URL: http://www.pepysdiary.test:8000/annotations/post/
Django Version: 5.0.7
Exception Type: InvalidURL
Exception Value: URL has an invalid label.
Exception Location: /usr/local/lib/python3.10/site-packages/requests/models.py, line 456, in prepare_url
Raised during: django_comments.views.comments.post_comment
Python Executable: /usr/local/bin/python
Python Version: 3.10.15
Python Path: ['/code',  '/usr/local/lib/python310.zip', '/usr/local/lib/python3.10', '/usr/local/lib/python3.10/lib-dynload', '/usr/local/lib/python3.10/site-packages']
Server time: Mon, 23 Sep 2024 12:25:03 +0000
```

The reason for this seems to be the following check in `spamchecker.py`.
```
if not hasattr(settings, "PEPYS_AKISMET_API_KEY"):
    # If it's not set we can't test.
    return False
```
When running in dev (with `DEBUG="True"`) `PEPYS_AKISMET_API_KEY` is set to an empty string (even if it is omitted from `.env`, an empty string is its default value). This means that `if not hasattr(settings, "PEPYS_AKISMET_API_KEY")` evaluates to `False`.

Changing the check to:
```
if not getattr(settings, "PEPYS_AKISMET_API_KEY", ""):
```
Made things work as expected.
</details>

I'm not sure if these changes belong in the PR. Maybe I am missing something obvious when it comes to running tests and working on this locally.

Happy for any feedback.