### PR TITLE
Fix URL truncation logic (#867): remove http(s), escape apostrophes, and preserve length

### DIFF
--- a/pepysdiary/common/templatetags/utility_filters.py
+++ b/pepysdiary/common/templatetags/utility_filters.py
@@ -1,8 +1,14 @@
+import html
+import re
+
 from django import template
 from django.contrib.humanize.templatetags.humanize import ordinal
+from django.template.defaultfilters import truncatechars, urlize
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
+URL_PATTERN = re.compile(r"(https?://\S+|www\.\S+)")
 
 @register.filter
 def to_class_name(value):
@@ -32,3 +38,31 @@ def ordinal_word(value):
         return terms[value]
     else:
         return ordinal(value)
+
+
+@register.filter
+def custom_urlizetrunc(comment_text, chrs):
+    """
+    Finds URLs and escapes apostrophes (' -> %27), preventing urlize from breaking.
+    Also removes 'http://' and 'https://' from the visible part of the URL for neatness.
+    https://github.com/philgyford/pepysdiary/issues/867
+    """
+    escaped_comment = URL_PATTERN.sub(
+        lambda m: m.group(0).replace("'", "%27"), comment_text
+    )
+    urlized_comment = urlize(escaped_comment)
+    anchor_tags = re.findall(r"(<a [^>]*>)(.*?)(</a>)", urlized_comment)
+    anchor_tags = list(set(anchor_tags)) # remove duplicates
+
+    for opening_tag, inner_text, closing_tag in anchor_tags:
+        cleaned_text = re.sub(r"^https?://", "", inner_text)
+
+        # Decode HTML entities before truncation to ensure correct character count
+        truncated_text = truncatechars(html.unescape(cleaned_text), chrs)
+
+        urlized_comment = urlized_comment.replace(
+            f"{opening_tag}{inner_text}{closing_tag}",
+            f"{opening_tag}{truncated_text}{closing_tag}",
+        )
+
+    return mark_safe(urlized_comment)

--- a/pepysdiary/templates/comments/flag.html
+++ b/pepysdiary/templates/comments/flag.html
@@ -1,5 +1,7 @@
 {% extends "common/layouts/base.html" %}
 
+{% load utility_filters %}
+
 {% block title %}Flag this?{% endblock %}
 {% block header_title %}Flag this?{% endblock %}
 
@@ -17,7 +19,7 @@
 						<small>on {{ comment.submit_date|date:date_format_mid }}</small>
 					</p>
 				</header>
-        {{ comment.comment|striptags|urlizetrunc:34|linebreaks }}
+        {{ comment.comment|striptags|custom_urlizetrunc:34|linebreaks }}
       </div>
     </article>
 	</section>

--- a/pepysdiary/templates/comments/inc/comment_form.html
+++ b/pepysdiary/templates/comments/inc/comment_form.html
@@ -8,6 +8,8 @@ Expects:
 
 {% endcomment %}
 
+{% load utility_filters %}
+
 {% if config and config.allow_comments %}
 	{% if object.allow_comments %}
 		{% if user.is_authenticated %}
@@ -49,7 +51,7 @@ Expects:
 										<span class="comment-name">{{ user.get_full_name }}</span>
 										<small>on {{ time_now|date:date_format_mid }}</small>
 									</h2>
-							        {{ form.comment.value|striptags|urlizetrunc:34|linebreaks }}
+							        {{ form.comment.value|striptags|custom_urlizetrunc:34|linebreaks }}
 							    </div>
 							</article>
 						</section>

--- a/pepysdiary/templates/comments/list.html
+++ b/pepysdiary/templates/comments/list.html
@@ -18,6 +18,7 @@ NOTE: The listings in templatetags/list_tags.py for the Recent Activity page
 	  and the preview in teamplates/inc/comment_form.html
       use similar HTML.
 {% endcomment %}
+
 {% load utility_filters %}
 
 <section id="{% if object and object.comment_name %}{{ object.comment_name }}{% else %}comment{% endif %}s" class="media-list comments">
@@ -70,7 +71,7 @@ NOTE: The listings in templatetags/list_tags.py for the Recent Activity page
 						</small>
 					</small>
 				</h3>
-		        {{ comment.comment|urlizetrunc:34|linebreaks }}
+		        {{ comment.comment|custom_urlizetrunc:34|linebreaks }}
 		    </div>
 		</article>
 	{% endfor %}

--- a/pepysdiary/templates/membership/person_detail.html
+++ b/pepysdiary/templates/membership/person_detail.html
@@ -31,7 +31,13 @@
                     </div>
                     <div class="form-group">
                         <span class="control-label label-static col-md-4">Website</span>
-                        <span class="col-md-8 form-control-static">{% if person.url %}<a href="{{ person.url }}" rel="nofollow">{{ person.url|urlizetrunc:34 }}</a>{% else %}<span class="text-muted">None</span>{% endif %}</span>
+                        <span class="col-md-8 form-control-static">
+                            {% if person.url %}
+                                <a href="{{ person.url }}" rel="nofollow">{{ person.url|truncatechars:34 }}</a>
+                            {% else %}
+                                <span class="text-muted">None</span>
+                            {% endif %}
+                        </span>
                     </div>
                 </div>
 
@@ -39,7 +45,7 @@
                 {# Public view. #}
 
                 {% if person.url %}
-                    <p class="lead">Website: <a href="{{ person.url }}" rel="nofollow">{{ person.url|urlizetrunc:34 }}</a></p>
+                    <p class="lead">Website: <a href="{{ person.url }}" rel="nofollow">{{ person.url|truncatechars:34 }}</a></p>
                 {% endif %}
 
             {% endif %}

--- a/tests/common/templatetags/test_utility_filters.py
+++ b/tests/common/templatetags/test_utility_filters.py
@@ -1,6 +1,12 @@
+import re
+
 from django.test import TestCase
 
-from pepysdiary.common.templatetags.utility_filters import ordinal_word, to_class_name
+from pepysdiary.common.templatetags.utility_filters import (
+    custom_urlizetrunc,
+    ordinal_word,
+    to_class_name,
+)
 from pepysdiary.diary.factories import EntryFactory
 from pepysdiary.encyclopedia.factories import TopicFactory
 from pepysdiary.letters.factories import LetterFactory
@@ -40,3 +46,90 @@ class OrdinalWordTestCase(TestCase):
 
         for num, term in terms.items():
             self.assertEqual(ordinal_word(num), term)
+
+
+class CustomUrlizeTruncTestCase(TestCase):
+    def test_basic_truncation(self):
+        comment = "Check this: https://example.com/a-very-long-url"
+        result = custom_urlizetrunc(comment, 20)
+        self.assertIn('<a href="https://example.com/a-very-long-url"', result)
+        self.assertIn(">example.com/a-very-…</a>", result)
+
+    def test_apostrophe_escaping(self):
+        comment = "Wow! https://example.com/O'Connor"
+        result = custom_urlizetrunc(comment, 50)
+        self.assertIn("O%27Connor", result)
+
+    def test_http_removal_in_visible_text(self):
+        comment = "Visit https://example.com for details."
+        result = custom_urlizetrunc(comment, 30)
+        self.assertIn('<a href="https://example.com"', result)
+        self.assertIn(">example.com</a>", result)
+
+    def test_www_url_truncation(self):
+        comment = "Check this: www.example.com/long-url"
+        result = custom_urlizetrunc(comment, 20)
+        self.assertIn('<a href="http://www.example.com/long-url"', result)
+        self.assertIn(">www.example.com/lon…</a>", result)
+
+    def test_multiple_identical_links(self):
+        comment = "Link: https://example.com/test and another https://example.com/test"
+        result = custom_urlizetrunc(comment, 15)
+        self.assertEqual(result.count(">example.com/te…</a>"), 2)
+
+    def test_mixed_text_and_links(self):
+        comment = "Comment with https://example.com/a/long/path and some more text."
+        result = custom_urlizetrunc(comment, 20)
+        self.assertIn('<a href="https://example.com/a/long/path"', result)
+        self.assertIn(">example.com/a/long/…</a>", result)
+
+    def test_long_url_with_query_params(self):
+        comment = "Here: https://example.com/path?query=1&value=2&count=3"
+        result = custom_urlizetrunc(comment, 34)
+        self.assertIn(">example.com/path?query=1&value=2&…</a>", result)
+
+    def test_url_with_link_to_highlight(self):
+        comment = "Here is a link to the page I was talking about https://threedecks.org/index.php?display_type=show_ship&id=2790#:~:text=British%20Fifth%20Rate%20ship%20'Nightingale'%20(1651).%20Dates%20of,armament,%20commanders,%20officers%20and%20crewmen,%20actions,%20battles,%20sources"
+        result = custom_urlizetrunc(comment, 34)
+        self.assertIn(">threedecks.org/index.php?display_…</a>", result)
+
+    def test_archive_dot_org_url(self):
+        comment = "THE ART OF MARBLE WORKING IN GENERAL link on the Wayback Machine:\
+        https://web.archive.org/web/20070208095349/http://www.cagenweb.com/quarries/articles_and_books/marble_workers_manual/mwh-p2_sect1.html"
+        result = custom_urlizetrunc(comment, 34)
+        self.assertIn("web.archive.org/web/2007020809534…", result)
+
+    def test_truncation_of_multiple_urls(self):
+        urls = [
+          "http://foo.com/blah_blah/baz/bar",
+          "http://foo.com/blah_blah/baz/bar/",
+          "http://foo.com/blah_blah_(wikipedia)",
+          "http://foo.com/blah_blah_(wikipedia)_(again)",
+          "http://www.example.com/wpstyle/?p=364",
+          "http://www.example.com/foo/?bar=baz&inga=42&quux",
+          "http://userid:password@example.com:8080",
+          "http://userid:password@example.com:8080/",
+          "http://userid@example.com/restricted",
+          "http://userid@example.com/restricted/",
+          "http://userid@example.com:8080",
+          "http://userid@example.com:8080/",
+          "http://userid:password@example.com",
+          "http://userid:password@example.com/",
+          "http://142.42.1.1/dictionary/wine/index.ssf?DEF_ID=2630&ISWINE=T",
+          "http://142.42.1.1:8080/e/eebo2/B02904.0001.001?view=toc",
+          "http://foo.com/blah_(wikipedia)#cite-1",
+          "http://foo.com/blah_(wikipedia)_blah#cite-1",
+          "http://foo.com/unicode_(✪)_in_parens",
+          "http://foo.com/(something)?after=parens",
+          "http://code.google.com/events/#&product=browser",
+          "https://shop.nationalarchives.gov.uk/products/a-z-charles-iis-london-1682?utm_source=emailmarketing&utm_medium=email&utm_campaign=shop_historic_london_azs&utm_content=2021-08-28",
+          "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+          "dict.leo.org/ende?lp=ende&lang=de&searchLoc=0&cmpType=relaxed&sectHdr=on",
+          "https://l.macys.com/new-york-ny/managers/valerie/perfumes/esquivel.html?ref=true",
+        ]
+
+        for url in urls:
+            cleaned_url = re.sub(r"^https?://", "", url)
+            expected_truncated = cleaned_url[:19] + "…"
+            result = custom_urlizetrunc(url, 20)
+            self.assertIn(expected_truncated, result)


### PR DESCRIPTION
See: https://github.com/philgyford/pepysdiary/issues/867
